### PR TITLE
Update avatar URL to use Google Drive link

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,7 +22,7 @@ model Users {
   refreshToken String?
 
   username  String  @unique
-  avatar    String  @default("https://lh3.google.com/u/0/d/1yhM-tDrQwh166RGAqTGzLKPvVri7jAKD")
+  avatar    String  @default("https://drive.google.com/uc?export=view&id=1yhM-tDrQwh166RGAqTGzLKPvVri7jAKD")
   biography String?
 
   createdAt DateTime @default(now())

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -246,7 +246,7 @@ export class UsersService {
     });
 
     // Update avatar on database
-    const avatarUrl = `https://lh3.googleusercontent.com/d/${response.data.id}`;
+    const avatarUrl = `https://drive.google.com/uc?export=view&id=${response.data.id}`;
     await this.update(userId, { avatar: avatarUrl });
   }
 


### PR DESCRIPTION
This pull request updates the avatar URL in the Users model and the UsersService class to use a Google Drive link instead of a Google Photos link. This change ensures that the avatar images are accessible and displayed correctly.