### PR TITLE
Refactor auth.service.ts to return tokens only in sign in and sign out methods

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -75,15 +75,7 @@ export class AuthService {
     const tokens = await this.getUserTokens(user);
     await this.updateRefreshToken(user.id, tokens.refreshToken);
 
-    return {
-      user: {
-        id: user.id,
-        username: user.username,
-        email: user.email,
-        role: user.role,
-      },
-      tokens,
-    };
+    return tokens;
   }
 
   async signOut(userId: string) {
@@ -116,15 +108,7 @@ export class AuthService {
     const tokens = await this.getUserTokens(user);
     await this.updateRefreshToken(user.id, tokens.refreshToken);
 
-    return {
-      user: {
-        id: user.id,
-        username: user.username,
-        email: user.email,
-        role: user.role,
-      },
-      tokens,
-    };
+    return tokens;
   }
 
   async updateRefreshToken(userId: string, refreshToken: string) {
@@ -138,6 +122,8 @@ export class AuthService {
     const jwtPayload: JwtPayloadCreate = {
       sub: user.id,
       username: user.username,
+      email: user.email,
+      avatar: user.avatar,
       role: user.role,
     };
 

--- a/src/auth/strategies/headerApiKey.strategy.ts
+++ b/src/auth/strategies/headerApiKey.strategy.ts
@@ -17,7 +17,8 @@ export class HeaderApiKeyStrategy extends PassportStrategy(
   async validate(apiKey: string, done: (error: Error, data) => void) {
     try {
       const keyReplace = apiKey.replace('apiKey', '').trim();
-      const isValid = keyReplace === this.configService.get('HEADER_API_KEY');
+      const decodedKey = Buffer.from(keyReplace, 'base64').toString('utf-8');
+      const isValid = decodedKey === this.configService.get('HEADER_API_KEY');
 
       if (!isValid) {
         return done(new UnauthorizedException(), false);

--- a/src/common/types/jwtPayloadCreate.type.ts
+++ b/src/common/types/jwtPayloadCreate.type.ts
@@ -1,5 +1,7 @@
 export type JwtPayloadCreate = {
   sub: string;
   username: string;
+  email: string;
+  avatar: string;
   role: string;
 };


### PR DESCRIPTION
This pull request refactors the auth.service.ts file to update the sign in and sign out methods to only return tokens instead of the entire user object. This improves the efficiency of the code and reduces unnecessary data transfer. Additionally, the HeaderApiKeyStrategy class is updated to decode the API key before validation. This ensures that the decoded key is compared to the configured HEADER_API_KEY value for authentication. The JwtPayloadCreate type is also updated to include the email and avatar fields.