### PR TITLE
Add film display and search endpoints

### DIFF
--- a/src/films/films.controller.ts
+++ b/src/films/films.controller.ts
@@ -31,6 +31,24 @@ export class FilmsController {
     return this.filmsService.addFilm(dto);
   }
 
+  @Get('total')
+  @UseGuards(HeaderApiKeyGuard)
+  async getTotalFilms() {
+    return this.filmsService.getTotalFilms();
+  }
+
+  @Get('display/search/:search')
+  @UseGuards(HeaderApiKeyGuard)
+  async searchFilms(@Param('search') search: string) {
+    return this.filmsService.searchFilms(search);
+  }
+
+  @Get('display/page/:page')
+  @UseGuards(HeaderApiKeyGuard)
+  async getFilmsByPage(@Param('page') page: string) {
+    return this.filmsService.getFilmsByPage(Number(page));
+  }
+
   @Get('search/:id')
   @UseGuards(HeaderApiKeyGuard)
   async getFilm(@Param('id') id: string) {

--- a/src/films/films.service.ts
+++ b/src/films/films.service.ts
@@ -81,6 +81,59 @@ export class FilmsService {
     });
   }
 
+  async getTotalFilms() {
+    return this.prisma.films.count();
+  }
+
+  async searchFilms(search: string) {
+    const films = await this.prisma.films.findMany({
+      take: 10,
+      where: {
+        OR: [
+          {
+            title: {
+              contains: search,
+              mode: 'insensitive',
+            },
+          },
+        ],
+      },
+      orderBy: {
+        releaseDate: 'desc',
+      },
+      select: {
+        id: true,
+        title: true,
+        genre: true,
+        poster: true,
+        rating: true,
+        totalReviews: true,
+      },
+    });
+
+    return films;
+  }
+
+  async getFilmsByPage(page: number) {
+    const films = await this.prisma.films.findMany({
+      skip: (page - 1) * 10,
+      take: 10,
+      orderBy: {
+        releaseDate: 'desc',
+      },
+      select: {
+        id: true,
+        title: true,
+        genre: true,
+        poster: true,
+        rating: true,
+        totalReviews: true,
+      },
+    });
+
+    return films;
+  }
+
   async getFilm(id: string) {
     // Check if the film exists
     const film = await this.findById(id);


### PR DESCRIPTION
This pull request adds new endpoints to the FilmsController for displaying and searching films. It also includes corresponding methods in the FilmsService to handle these requests. The new endpoints allow users to retrieve films by page, search for films based on a search term, and get the total number of films in the database. These additions enhance the functionality of the application and improve the user experience.