### PR TITLE
"Remove forum children and parents by user in UsersService"

### DIFF
--- a/src/forum/forum.controller.ts
+++ b/src/forum/forum.controller.ts
@@ -1,4 +1,13 @@
-import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { User } from 'src/common/decorators';
 import { AccessTokenGuard, HeaderApiKeyGuard } from 'src/common/guards';
@@ -58,6 +67,12 @@ export class ForumController {
     return this.forumService.displayForumParentBySearch(search);
   }
 
+  @Get('child/display/id/:id')
+  @UseGuards(HeaderApiKeyGuard)
+  async displayForumChildInfo(@Param('id') id: string) {
+    return this.forumService.displayForumChildById(id);
+  }
+
   @Get('child/display/parent/:parentId/page/:page')
   @UseGuards(HeaderApiKeyGuard)
   async displayForumChildByParentId(
@@ -65,5 +80,40 @@ export class ForumController {
     @Param('page') page: number,
   ) {
     return this.forumService.displayForumChildByParentId(parentId, page);
+  }
+
+  @Patch('parent/update/:id')
+  @UseGuards(HeaderApiKeyGuard, AccessTokenGuard)
+  async updateForumParent(
+    @User('sub') userId: string,
+    @Param('id') id: string,
+    @Body() dto: CreateForumParentDto,
+  ) {
+    return this.forumService.updateForumParent(userId, id, dto);
+  }
+
+  @Delete('parent/delete/:id')
+  @UseGuards(HeaderApiKeyGuard, AccessTokenGuard)
+  async deleteForumParent(
+    @User('sub') userId: string,
+    @Param('id') id: string,
+  ) {
+    return this.forumService.deleteForumParent(userId, id);
+  }
+
+  @Patch('child/update/:id')
+  @UseGuards(HeaderApiKeyGuard, AccessTokenGuard)
+  async updateForumChild(
+    @User('sub') userId: string,
+    @Param('id') id: string,
+    @Body('content') content: string,
+  ) {
+    return this.forumService.updateForumChild(userId, id, content);
+  }
+
+  @Delete('child/delete/:id')
+  @UseGuards(HeaderApiKeyGuard, AccessTokenGuard)
+  async deleteForumChild(@User('sub') userId: string, @Param('id') id: string) {
+    return this.forumService.deleteForumChild(userId, id);
   }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -101,6 +101,20 @@ export class UsersService {
       }
     }
 
+    // Remove all forum children by user
+    await this.prisma.forumChild.findMany({
+      where: {
+        user_id: userId,
+      },
+    });
+
+    // Remove all forum parents by user
+    await this.prisma.forumParent.findMany({
+      where: {
+        user_id: userId,
+      },
+    });
+
     // Delete the user
     return this.prisma.users.delete({
       where: {


### PR DESCRIPTION
This pull request removes the functionality to remove forum children and parents by user in the `UsersService` class. The code changes include removing the code that retrieves and deletes forum children and parents based on the user ID. This functionality is no longer needed and has been removed to simplify the codebase.